### PR TITLE
improve example find command, reducing overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Get study list:
 
 `dicomweb_client --url http://localhost:5985 search studies`
 
-Store a DATA_DIRECTORY of DICOM image files (here with the ".IMA" extension).  Adjust the command line to match the location and naming of your files).
+Store a DATA_DIRECTORY of DICOM image files (here with the ".IMA" extension).  Adjust the command line to match the location and naming of your files.  (The `-n25` option to xargs is for batching files, leading to fewer calls and thus less overhead.)
 
-`find DATA_DIRECTORY -iname \*.IMA -exec dicomweb_client --url http://localhost:5985 store instances \{\} \;`
+`find DATA_DIRECTORY -iname \*.IMA -print0 | xargs -0 -n25 dicomweb_client --url http://localhost:5985 store instances`
 
 
 ## Use with a viewer


### PR DESCRIPTION
This change suggests using xargs to call dicomweb client on *batches* of files.
(`-print0 | xargs -0` is for extra safety and would even work with newlines in filenames.)