### PR TITLE
Revert "fix: Remove unnecessary use of underscore for Array find/filt…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dicomweb-server",
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,20 +25,20 @@
       }
     },
     "@babel/polyfill": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.1.tgz",
-      "integrity": "sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
+      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
       "requires": {
         "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+      "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@types/caseless": {
@@ -577,14 +577,14 @@
       }
     },
     "dcmjs": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/dcmjs/-/dcmjs-0.13.2.tgz",
-      "integrity": "sha512-lTtGsUSLW53VXr/bzNqWG+mZoPrd3gTrRd2mgFBSYTSxBsEcKmFzD2FsOADYQ5DD02pthxuoHx5FjyjGcN2GLA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/dcmjs/-/dcmjs-0.8.3.tgz",
+      "integrity": "sha512-eXQjqgtJf9+oseraKDNDm2A5F3Th4B2GJeZtjStj0IFXxjlbPOzdq3PfCyxdwfRaKOBIwr0q3YK/Vfs2CpQY8Q==",
       "requires": {
-        "@babel/polyfill": "^7.8.3",
-        "@babel/runtime": "^7.8.4",
+        "@babel/polyfill": "^7.6.0",
+        "@babel/runtime": "^7.6.3",
         "loglevelnext": "^3.0.1",
-        "ndarray": "^1.0.19"
+        "ndarray": "^1.0.18"
       }
     },
     "debug": {
@@ -2236,9 +2236,9 @@
       "dev": true
     },
     "ndarray": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
-      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
+      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
       "requires": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
@@ -2715,9 +2715,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -3480,6 +3480,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
-    "dcmjs": "0.13.2",
+    "dcmjs": "0.8.3",
     "fastify": "^2.10.0",
     "fastify-basic-auth": "^0.5.0",
     "fastify-cors": "^3.0.0",
@@ -23,6 +23,7 @@
     "p-queue": "^6.2.1",
     "split2": "^3.1.1",
     "to-array-buffer": "^3.2.0",
+    "underscore": "^1.9.1",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {

--- a/plugins/CouchDB.js
+++ b/plugins/CouchDB.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle, no-async-promise-executor */
 const fp = require('fastify-plugin');
+const _ = require('underscore');
 const toArrayBuffer = require('to-array-buffer');
 // eslint-disable-next-line no-global-assign
 window = {};
@@ -176,7 +177,7 @@ async function couchdb(fastify, options) {
       Promise.all([bodySeriesInfo, bodyStudies])
         .then(values => {
           const studies = {};
-          studies.rows = values[1].rows.filter(obj =>
+          studies.rows = _.filter(values[1].rows, obj =>
             fastify.queryObj(request.query, obj.key[1], queryKeys)
           );
           const res = [];
@@ -222,7 +223,7 @@ async function couchdb(fastify, options) {
                           // if both studies have values, cumulate them but don't make duplicates
                           (typeof studySeriesObj[tag].Value[0] === 'string' &&
                             !studySeriesObj[tag].Value.includes(val)) ||
-                          !studySeriesObj[tag].Value.findIndex(val) === -1
+                          !_.findIndex(studySeriesObj[tag].Value, val) === -1
                         ) {
                           studySeriesObj[tag].Value.push(val);
                         }
@@ -743,7 +744,7 @@ async function couchdb(fastify, options) {
         },
         async (error, body) => {
           if (!error) {
-            const docs = body.rows.map(instance => {
+            const docs = _.map(body.rows, instance => {
               return { _id: instance.key[2], _rev: instance.doc._rev, _deleted: true };
             });
             await fastify.dbPqueue.add(() => {
@@ -787,7 +788,7 @@ async function couchdb(fastify, options) {
         },
         async (error, body) => {
           if (!error) {
-            const docs = body.rows.map(instance => {
+            const docs = _.map(body.rows, instance => {
               return { _id: instance.key[2], _rev: instance.doc._rev, _deleted: true };
             });
             await fastify.dbPqueue.add(() => {


### PR DESCRIPTION
…er/map. Bump dcmjs version"

This reverts commit 8b3ecfe92a2f0fd620334b1f90b462bf46285e27.


Reverting this previous change because apparently _.findIndex fails gracefully for string values, whereas native ES6 doesn't, and reverting is easier than fixing the issues. I still don't think we need underscore though. 