### PR TITLE
chore: Add dockerfile and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.circleci
+.prettierrc
+.eslintignore
+.git
+couchdb-data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 package-lock.json
 config/*.json
+couchdb-data
+.idea
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# docker build -t ohif/dicomweb-server:latest .
+# docker run -p 5985:5985 ohif/dicomweb-server:latest
+# If you want to use PouchDB in this container, add -p 5984:5984
+# docker run -p 5985:5985 -p 5984:5984 -e USE_POUCHDB=true -e DB_SERVER=http://0.0.0.0 ohif/dicomweb-server:latest
+FROM node:13.10.1-slim
+
+# Install prerequisites
+RUN apt-get update
+RUN apt-get -y install supervisor
+
+USER node
+RUN mkdir -p /home/node/app
+RUN mkdir -p /home/node/log/supervisor
+WORKDIR /home/node/app
+ADD . /home/node/app
+
+# Restore deps
+RUN npm ci
+RUN npm install pouchdb-server@4.2.0
+
+ENV USE_POUCHDB=false
+
+EXPOSE 5984 5985
+CMD ["supervisord", "-n", "-c", "/home/node/app/dockersupport/supervisord.conf"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+# docker-compose up
+# curl -X PUT http://127.0.0.1:5984/_users
+# curl -X PUT http://127.0.0.1:5984/_replicator
+# curl -X PUT http://127.0.0.1:5984/_global_changes
+# curl -X PUT http://127.0.0.1:5984/chronicle
+# http://localhost:5984/_utils/
+version: '3.8'
+
+services:
+  dicomweb:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ohif/dicomweb-server:latest
+    hostname: dicomweb-server
+    environment:
+      - PORT=5984
+      - DB_SERVER=http://couchdb
+    ports:
+      - '5985:5985'
+    depends_on:
+      - couchdb
+    restart: unless-stopped
+
+  ##
+  # LINK: https://hub.docker.com/_/couchdb
+  ##
+  couchdb:
+    image: couchdb:2.3.1
+    hostname: couchdb
+    volumes:
+      - ./couchdb-data:/opt/couchdb/data
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=password
+    ports:
+      - '5984:5984'
+    restart: unless-stopped

--- a/dockersupport/conditionally-start-pouchdb.sh
+++ b/dockersupport/conditionally-start-pouchdb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $USE_POUCHDB = "true" ]
+then
+    echo "USE_POUCHDB is true, starting PouchDB service"
+    /home/node/app/node_modules/pouchdb-server/bin/pouchdb-server --in-memory --host 0.0.0.0
+else
+    exit 0
+fi

--- a/dockersupport/dicomweb-server-service.sh
+++ b/dockersupport/dicomweb-server-service.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /home/node/app
+npm start

--- a/dockersupport/supervisord.conf
+++ b/dockersupport/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+user=node
+logfile=/home/node/log/supervisor/supervisord.log
+nodaemon=true
+
+[program:pouchdb]
+command=bash /home/node/app/dockersupport/conditionally-start-pouchdb.sh
+stdout_logfile=/home/node/log/supervisor/%(program_name)s.log
+stderr_logfile=/home/node/log/supervisor/%(program_name)s.log
+autorestart=true
+
+[program:dicomweb-server]
+command=bash /home/node/app/dockersupport/dicomweb-server-service.sh
+stdout_logfile=/home/node/log/supervisor/%(program_name)s.log
+stderr_logfile=/home/node/log/supervisor/%(program_name)s.log
+autorestart=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dicomweb-server",
   "version": "0.0.0-development",
   "description": "Lightweight DICOMweb Server with CouchDB",
+  "repository": "https://github.com/dcmjs-org/dicomweb-server",
   "main": "server.js",
   "dependencies": {
     "atob": "^2.1.2",


### PR DESCRIPTION
Similar to the `dockerization` branch and the PR here: https://github.com/dcmjs-org/dicomweb-server/pull/20

This adds:
- Dockerfile for standalone usage using PouchDB in a single container (USE_POUCHDB=true)
- docker-compose for two-container usage using CouchDB as a separate container

The dockerfile runs them using supervisord, and will conditionally start PouchDB if the flag is set. If you want to use PouchDB you should expose port 5984 as well.

Both of them seem to work fine for me, though we may need to add some startup script to create _users, _replications, etc... for normal CouchDB setups.

TODO:
- [ ] Is this the right docker name? What are we using right now?
- [ ] Make the CI workflow build and push new versions to Docker on merge, or optionally per PR